### PR TITLE
Fix citations to Philemon: no chapter num's in BCP

### DIFF
--- a/commonprayer/src/assets/lectionary/rcl1.json
+++ b/commonprayer/src/assets/lectionary/rcl1.json
@@ -4885,7 +4885,7 @@
     "day": "proper-18",
     "lectionary": "rclsundayTrack1",
     "type": "second_reading",
-    "citation": "Philemon 1:1-21"
+    "citation": "Philemon 1-21"
   },
   {
     "whentype": "year",

--- a/commonprayer/src/assets/lectionary/rcl2.json
+++ b/commonprayer/src/assets/lectionary/rcl2.json
@@ -8709,7 +8709,7 @@
     "day": "proper-18",
     "lectionary": "rclsunday",
     "type": "second_reading",
-    "citation": "Philemon 1:1-21"
+    "citation": "Philemon 1-21"
   },
   {
     "whentype": "year",


### PR DESCRIPTION
BCP doesn't insert a chapter citation for Philemon (BCP, 920 - Proper 18-C). 